### PR TITLE
Add out-of-box support for Swift 4.2.

### DIFF
--- a/Sources/UtiliKit/Container/ContainerViewController+ManagedChildren.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController+ManagedChildren.swift
@@ -25,7 +25,11 @@ public extension ContainerViewController {
     // MARK: Removing a Child
     func removeChild(_ child: Child) {
         let removed = managedChildren.index(of: child).flatMap { managedChildren.remove(at: $0) }
+        #if swift(>=4.2)
+        removed?.viewController.removeFromParent()
+        #else
         removed?.viewController.removeFromParentViewController()
+        #endif
     }
     
     func removeChildren(where predicate: (Child) -> Bool) {

--- a/Sources/UtiliKit/Container/ContainerViewController+ManagedChildren.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController+ManagedChildren.swift
@@ -22,9 +22,9 @@ public extension ContainerViewController {
         return nextIndex < managedChildren.endIndex ? nextIndex : nil
     }
     
-    // MARK: Removing a Child
-    func removeChild(_ child: Child) {
-        let removed = managedChildren.index(of: child).flatMap { managedChildren.remove(at: $0) }
+    // MARK: Removing a ManagedChild
+    func removeChild(_ child: ManagedChild) {
+        let removed = managedChildren.index { $0.identifier == child.identifier }.flatMap { managedChildren.remove(at: $0) }
         #if swift(>=4.2)
         removed?.viewController.removeFromParent()
         #else

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -131,9 +131,15 @@ private extension ContainerViewController {
     func prepareForTransitioning(from source: UIViewController?, to destination: UIViewController, animated: Bool) {
         isTransitioning = true
         
+        #if swift(>=4.2)
+        source?.willMove(toParent: nil)
+        destination.willMove(toParent: self)
+        addChild(destination)
+        #else
         source?.willMove(toParentViewController: nil)
         destination.willMove(toParentViewController: self)
         addChildViewController(destination)
+        #endif
     }
     
     func configure(destinationView: UIView, inContainer container: UIView) {
@@ -143,9 +149,15 @@ private extension ContainerViewController {
     
     func finishTransitioning(from source: UIViewController?, to destination: UIViewController, animated: Bool) {
         source?.view.removeFromSuperview()
+        #if swift(>=4.2)
+        source?.removeFromParent()
+        source?.didMove(toParent: nil)
+        destination.didMove(toParent: self)
+        #else
         source?.removeFromParentViewController()
         source?.didMove(toParentViewController: nil)
         destination.didMove(toParentViewController: self)
+        #endif
         
         visibleController = destination
         isTransitioning = false

--- a/Sources/UtiliKit/Instantiation/UICollectionView+Extensions.swift
+++ b/Sources/UtiliKit/Instantiation/UICollectionView+Extensions.swift
@@ -17,8 +17,18 @@ public extension UICollectionView {
         /// Either UICollectionElementKindSectionHeader or UICollectionElementKindSectionFooter
         var type: String {
             switch self {
-            case .sectionHeader: return UICollectionElementKindSectionHeader
-            case .sectionFooter: return UICollectionElementKindSectionFooter
+            case .sectionHeader:
+                #if swift(>=4.2)
+                return UICollectionView.elementKindSectionHeader
+                #else
+                return UICollectionElementKindSectionHeader
+                #endif
+            case .sectionFooter:
+                #if swift(>=4.2)
+                return UICollectionView.elementKindSectionFooter
+                #else
+                return UICollectionElementKindSectionFooter
+                #endif
             }
         }
     }

--- a/UtiliKit.xcodeproj/project.pbxproj
+++ b/UtiliKit.xcodeproj/project.pbxproj
@@ -1,942 +1,942 @@
 // !$*UTF8*$!
 {
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
+    archiveVersion = 1;
+    classes = {
+    };
+    objectVersion = 46;
+    objects = {
 
 /* Begin PBXBuildFile section */
-		0E6E8C6D2112551200617815 /* ContainerViewController+ManagedChildren.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6E8C6C2112551200617815 /* ContainerViewController+ManagedChildren.swift */; };
-		0EC8025C209CE9C90051F732 /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC8025B209CE9C90051F732 /* Configurable.swift */; };
-		0ED9476420FD473700B642AB /* ContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED9476220FD461300B642AB /* ContainerTests.swift */; };
-		1D419DBD21235EE100B62D91 /* ManagedChild.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D419DBC21235EE100B62D91 /* ManagedChild.swift */; };
-		1D419DBF21236CC300B62D91 /* UtiliKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8677313920601BB400C54343 /* UtiliKit.framework */; };
-		8677314220601BB400C54343 /* UtiliKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8677313920601BB400C54343 /* UtiliKit.framework */; };
-		8677315720601D1A00C54343 /* UtiliKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869826261FE87BFA0024B73D /* UtiliKitTests.swift */; };
-		8677315820601D1A00C54343 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869826271FE87BFA0024B73D /* DateTests.swift */; };
-		8698CFB920619EAD0065AE20 /* UtiliKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8698CFA020619EAD0065AE20 /* UtiliKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8698CFBA20619EAD0065AE20 /* ContainerTransitionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA320619EAD0065AE20 /* ContainerTransitionContext.swift */; };
-		8698CFBB20619EAD0065AE20 /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA420619EAD0065AE20 /* ContainerViewController.swift */; };
-		8698CFBC20619EAD0065AE20 /* ContainerViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA520619EAD0065AE20 /* ContainerViewControllerDelegate.swift */; };
-		8698CFBD20619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA620619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift */; };
-		8698CFBE20619EAD0065AE20 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA820619EAD0065AE20 /* FileManager+Extensions.swift */; };
-		8698CFBF20619EAD0065AE20 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA920619EAD0065AE20 /* UIView+Extensions.swift */; };
-		8698CFC020619EAD0065AE20 /* MKMapView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAB20619EAD0065AE20 /* MKMapView+Extensions.swift */; };
-		8698CFC120619EAD0065AE20 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAC20619EAD0065AE20 /* NibLoadable.swift */; };
-		8698CFC220619EAD0065AE20 /* ReuseIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAD20619EAD0065AE20 /* ReuseIdentifiable.swift */; };
-		8698CFC320619EAD0065AE20 /* StoryboardIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAE20619EAD0065AE20 /* StoryboardIdentifiable.swift */; };
-		8698CFC420619EAD0065AE20 /* UICollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAF20619EAD0065AE20 /* UICollectionView+Extensions.swift */; };
-		8698CFC520619EAD0065AE20 /* UIStoryboard+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB020619EAD0065AE20 /* UIStoryboard+Extensions.swift */; };
-		8698CFC620619EAD0065AE20 /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB120619EAD0065AE20 /* UITableView+Extensions.swift */; };
-		8698CFC720619EAD0065AE20 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB320619EAD0065AE20 /* Date+Extensions.swift */; };
-		8698CFC820619EAD0065AE20 /* TimelessDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB420619EAD0065AE20 /* TimelessDate.swift */; };
-		8698CFC920619EAD0065AE20 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB620619EAD0065AE20 /* Bundle+Extensions.swift */; };
-		8698CFCA20619EAD0065AE20 /* VersionConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB720619EAD0065AE20 /* VersionConfig.swift */; };
-		8698D00A2061A3930065AE20 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFE32061A3930065AE20 /* AppDelegate.swift */; };
-		8698D00B2061A3930065AE20 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFE42061A3930065AE20 /* LaunchScreen.xib */; };
-		8698D00C2061A3930065AE20 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFE62061A3930065AE20 /* Main.storyboard */; };
-		8698D00D2061A3930065AE20 /* CollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFE92061A3930065AE20 /* CollectionViewController.swift */; };
-		8698D00E2061A3930065AE20 /* ProgrammaticCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFEA2061A3930065AE20 /* ProgrammaticCell.swift */; };
-		8698D00F2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFEB2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift */; };
-		8698D0102061A3930065AE20 /* ProgrammaticViewsCollectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFEC2061A3930065AE20 /* ProgrammaticViewsCollectionController.swift */; };
-		8698D0112061A3930065AE20 /* ContainerExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFED2061A3930065AE20 /* ContainerExampleViewController.swift */; };
-		8698D0122061A3930065AE20 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFEE2061A3930065AE20 /* Images.xcassets */; };
-		8698D0142061A3930065AE20 /* CustomAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF12061A3930065AE20 /* CustomAnnotation.swift */; };
-		8698D0152061A3930065AE20 /* MapController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF22061A3930065AE20 /* MapController.swift */; };
-		8698D0162061A3930065AE20 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF32061A3930065AE20 /* MapViewController.swift */; };
-		8698D0172061A3930065AE20 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF52061A3930065AE20 /* TableViewController.swift */; };
-		8698D0182061A3930065AE20 /* XibFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF62061A3930065AE20 /* XibFooterView.swift */; };
-		8698D0192061A3930065AE20 /* XibFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFF72061A3930065AE20 /* XibFooterView.xib */; };
-		8698D01A2061A3930065AE20 /* XibHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF82061A3930065AE20 /* XibHeaderView.swift */; };
-		8698D01B2061A3930065AE20 /* XibHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFF92061A3930065AE20 /* XibHeaderView.xib */; };
-		8698D01C2061A3930065AE20 /* XibTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFA2061A3930065AE20 /* XibTableViewCell.swift */; };
-		8698D01D2061A3930065AE20 /* XibTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFFB2061A3930065AE20 /* XibTableViewCell.xib */; };
-		8698D01E2061A3930065AE20 /* XibViewsTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFC2061A3930065AE20 /* XibViewsTableController.swift */; };
-		8698D01F2061A3930065AE20 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFE2061A3930065AE20 /* ViewController.swift */; };
-		8698D0202061A3930065AE20 /* XibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFF2061A3930065AE20 /* XibView.swift */; };
-		8698D0212061A3930065AE20 /* XibView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698D0002061A3930065AE20 /* XibView.xib */; };
-		8698D0222061A3930065AE20 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0022061A3930065AE20 /* InitialViewController.swift */; };
-		8698D0232061A3930065AE20 /* NamedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0032061A3930065AE20 /* NamedViewController.swift */; };
-		8698D0242061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0042061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift */; };
-		8698D0252061A3930065AE20 /* VCTest.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8698D0052061A3930065AE20 /* VCTest.storyboard */; };
-		8698D0262061A3930065AE20 /* VCViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0062061A3930065AE20 /* VCViewController.swift */; };
-		8698D0272061A3930065AE20 /* ViewControllerA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0072061A3930065AE20 /* ViewControllerA.swift */; };
-		8698D0282061A3930065AE20 /* ViewControllerB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0082061A3930065AE20 /* ViewControllerB.swift */; };
-		8698D0292061A3930065AE20 /* WipeTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0092061A3930065AE20 /* WipeTransitionAnimator.swift */; };
+        0E6E8C6D2112551200617815 /* ContainerViewController+ManagedChildren.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E6E8C6C2112551200617815 /* ContainerViewController+ManagedChildren.swift */; };
+        0EC8025C209CE9C90051F732 /* Configurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EC8025B209CE9C90051F732 /* Configurable.swift */; };
+        0ED9476420FD473700B642AB /* ContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ED9476220FD461300B642AB /* ContainerTests.swift */; };
+        1D419DBD21235EE100B62D91 /* ManagedChild.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D419DBC21235EE100B62D91 /* ManagedChild.swift */; };
+        1D419DBF21236CC300B62D91 /* UtiliKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8677313920601BB400C54343 /* UtiliKit.framework */; };
+        8677314220601BB400C54343 /* UtiliKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8677313920601BB400C54343 /* UtiliKit.framework */; };
+        8677315720601D1A00C54343 /* UtiliKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869826261FE87BFA0024B73D /* UtiliKitTests.swift */; };
+        8677315820601D1A00C54343 /* DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869826271FE87BFA0024B73D /* DateTests.swift */; };
+        8698CFB920619EAD0065AE20 /* UtiliKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 8698CFA020619EAD0065AE20 /* UtiliKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+        8698CFBA20619EAD0065AE20 /* ContainerTransitionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA320619EAD0065AE20 /* ContainerTransitionContext.swift */; };
+        8698CFBB20619EAD0065AE20 /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA420619EAD0065AE20 /* ContainerViewController.swift */; };
+        8698CFBC20619EAD0065AE20 /* ContainerViewControllerDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA520619EAD0065AE20 /* ContainerViewControllerDelegate.swift */; };
+        8698CFBD20619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA620619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift */; };
+        8698CFBE20619EAD0065AE20 /* FileManager+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA820619EAD0065AE20 /* FileManager+Extensions.swift */; };
+        8698CFBF20619EAD0065AE20 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFA920619EAD0065AE20 /* UIView+Extensions.swift */; };
+        8698CFC020619EAD0065AE20 /* MKMapView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAB20619EAD0065AE20 /* MKMapView+Extensions.swift */; };
+        8698CFC120619EAD0065AE20 /* NibLoadable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAC20619EAD0065AE20 /* NibLoadable.swift */; };
+        8698CFC220619EAD0065AE20 /* ReuseIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAD20619EAD0065AE20 /* ReuseIdentifiable.swift */; };
+        8698CFC320619EAD0065AE20 /* StoryboardIdentifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAE20619EAD0065AE20 /* StoryboardIdentifiable.swift */; };
+        8698CFC420619EAD0065AE20 /* UICollectionView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFAF20619EAD0065AE20 /* UICollectionView+Extensions.swift */; };
+        8698CFC520619EAD0065AE20 /* UIStoryboard+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB020619EAD0065AE20 /* UIStoryboard+Extensions.swift */; };
+        8698CFC620619EAD0065AE20 /* UITableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB120619EAD0065AE20 /* UITableView+Extensions.swift */; };
+        8698CFC720619EAD0065AE20 /* Date+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB320619EAD0065AE20 /* Date+Extensions.swift */; };
+        8698CFC820619EAD0065AE20 /* TimelessDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB420619EAD0065AE20 /* TimelessDate.swift */; };
+        8698CFC920619EAD0065AE20 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB620619EAD0065AE20 /* Bundle+Extensions.swift */; };
+        8698CFCA20619EAD0065AE20 /* VersionConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFB720619EAD0065AE20 /* VersionConfig.swift */; };
+        8698D00A2061A3930065AE20 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFE32061A3930065AE20 /* AppDelegate.swift */; };
+        8698D00B2061A3930065AE20 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFE42061A3930065AE20 /* LaunchScreen.xib */; };
+        8698D00C2061A3930065AE20 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFE62061A3930065AE20 /* Main.storyboard */; };
+        8698D00D2061A3930065AE20 /* CollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFE92061A3930065AE20 /* CollectionViewController.swift */; };
+        8698D00E2061A3930065AE20 /* ProgrammaticCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFEA2061A3930065AE20 /* ProgrammaticCell.swift */; };
+        8698D00F2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFEB2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift */; };
+        8698D0102061A3930065AE20 /* ProgrammaticViewsCollectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFEC2061A3930065AE20 /* ProgrammaticViewsCollectionController.swift */; };
+        8698D0112061A3930065AE20 /* ContainerExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFED2061A3930065AE20 /* ContainerExampleViewController.swift */; };
+        8698D0122061A3930065AE20 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFEE2061A3930065AE20 /* Images.xcassets */; };
+        8698D0142061A3930065AE20 /* CustomAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF12061A3930065AE20 /* CustomAnnotation.swift */; };
+        8698D0152061A3930065AE20 /* MapController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF22061A3930065AE20 /* MapController.swift */; };
+        8698D0162061A3930065AE20 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF32061A3930065AE20 /* MapViewController.swift */; };
+        8698D0172061A3930065AE20 /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF52061A3930065AE20 /* TableViewController.swift */; };
+        8698D0182061A3930065AE20 /* XibFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF62061A3930065AE20 /* XibFooterView.swift */; };
+        8698D0192061A3930065AE20 /* XibFooterView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFF72061A3930065AE20 /* XibFooterView.xib */; };
+        8698D01A2061A3930065AE20 /* XibHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFF82061A3930065AE20 /* XibHeaderView.swift */; };
+        8698D01B2061A3930065AE20 /* XibHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFF92061A3930065AE20 /* XibHeaderView.xib */; };
+        8698D01C2061A3930065AE20 /* XibTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFA2061A3930065AE20 /* XibTableViewCell.swift */; };
+        8698D01D2061A3930065AE20 /* XibTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698CFFB2061A3930065AE20 /* XibTableViewCell.xib */; };
+        8698D01E2061A3930065AE20 /* XibViewsTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFC2061A3930065AE20 /* XibViewsTableController.swift */; };
+        8698D01F2061A3930065AE20 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFE2061A3930065AE20 /* ViewController.swift */; };
+        8698D0202061A3930065AE20 /* XibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698CFFF2061A3930065AE20 /* XibView.swift */; };
+        8698D0212061A3930065AE20 /* XibView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8698D0002061A3930065AE20 /* XibView.xib */; };
+        8698D0222061A3930065AE20 /* InitialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0022061A3930065AE20 /* InitialViewController.swift */; };
+        8698D0232061A3930065AE20 /* NamedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0032061A3930065AE20 /* NamedViewController.swift */; };
+        8698D0242061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0042061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift */; };
+        8698D0252061A3930065AE20 /* VCTest.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8698D0052061A3930065AE20 /* VCTest.storyboard */; };
+        8698D0262061A3930065AE20 /* VCViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0062061A3930065AE20 /* VCViewController.swift */; };
+        8698D0272061A3930065AE20 /* ViewControllerA.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0072061A3930065AE20 /* ViewControllerA.swift */; };
+        8698D0282061A3930065AE20 /* ViewControllerB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0082061A3930065AE20 /* ViewControllerB.swift */; };
+        8698D0292061A3930065AE20 /* WipeTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8698D0092061A3930065AE20 /* WipeTransitionAnimator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		8677314320601BB400C54343 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 607FACC81AFB9204008FA782 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8677313820601BB400C54343;
-			remoteInfo = "UtiliKit-iOS";
-		};
+        8677314320601BB400C54343 /* PBXContainerItemProxy */ = {
+            isa = PBXContainerItemProxy;
+            containerPortal = 607FACC81AFB9204008FA782 /* Project object */;
+            proxyType = 1;
+            remoteGlobalIDString = 8677313820601BB400C54343;
+            remoteInfo = "UtiliKit-iOS";
+        };
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0E6E8C6C2112551200617815 /* ContainerViewController+ManagedChildren.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerViewController+ManagedChildren.swift"; sourceTree = "<group>"; };
-		0EC8025B209CE9C90051F732 /* Configurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurable.swift; sourceTree = "<group>"; };
-		0ED9476220FD461300B642AB /* ContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTests.swift; sourceTree = "<group>"; };
-		1D419DBC21235EE100B62D91 /* ManagedChild.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedChild.swift; sourceTree = "<group>"; };
-		8677313920601BB400C54343 /* UtiliKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UtiliKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8677314120601BB400C54343 /* UtiliKit-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UtiliKit-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8677315A20601DD800C54343 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		869826261FE87BFA0024B73D /* UtiliKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtiliKitTests.swift; sourceTree = "<group>"; };
-		869826271FE87BFA0024B73D /* DateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
-		8698CF9F20619EAD0065AE20 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8698CFA020619EAD0065AE20 /* UtiliKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UtiliKit.h; sourceTree = "<group>"; };
-		8698CFA320619EAD0065AE20 /* ContainerTransitionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTransitionContext.swift; sourceTree = "<group>"; };
-		8698CFA420619EAD0065AE20 /* ContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
-		8698CFA520619EAD0065AE20 /* ContainerViewControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewControllerDelegate.swift; sourceTree = "<group>"; };
-		8698CFA620619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewControllerTransitionAnimator.swift; sourceTree = "<group>"; };
-		8698CFA820619EAD0065AE20 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFA920619EAD0065AE20 /* UIView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFAB20619EAD0065AE20 /* MKMapView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MKMapView+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFAC20619EAD0065AE20 /* NibLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibLoadable.swift; sourceTree = "<group>"; };
-		8698CFAD20619EAD0065AE20 /* ReuseIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReuseIdentifiable.swift; sourceTree = "<group>"; };
-		8698CFAE20619EAD0065AE20 /* StoryboardIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardIdentifiable.swift; sourceTree = "<group>"; };
-		8698CFAF20619EAD0065AE20 /* UICollectionView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFB020619EAD0065AE20 /* UIStoryboard+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFB120619EAD0065AE20 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFB320619EAD0065AE20 /* Date+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFB420619EAD0065AE20 /* TimelessDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelessDate.swift; sourceTree = "<group>"; };
-		8698CFB620619EAD0065AE20 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
-		8698CFB720619EAD0065AE20 /* VersionConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionConfig.swift; sourceTree = "<group>"; };
-		8698CFD02061A19D0065AE20 /* UtiliKit-iOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "UtiliKit-iOSExample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8698CFE32061A3930065AE20 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		8698CFE52061A3930065AE20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
-		8698CFE72061A3930065AE20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		8698CFE92061A3930065AE20 /* CollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewController.swift; sourceTree = "<group>"; };
-		8698CFEA2061A3930065AE20 /* ProgrammaticCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgrammaticCell.swift; sourceTree = "<group>"; };
-		8698CFEB2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgrammaticHeaderFooterView.swift; sourceTree = "<group>"; };
-		8698CFEC2061A3930065AE20 /* ProgrammaticViewsCollectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgrammaticViewsCollectionController.swift; sourceTree = "<group>"; };
-		8698CFED2061A3930065AE20 /* ContainerExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerExampleViewController.swift; sourceTree = "<group>"; };
-		8698CFEE2061A3930065AE20 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
-		8698CFEF2061A3930065AE20 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8698CFF12061A3930065AE20 /* CustomAnnotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomAnnotation.swift; sourceTree = "<group>"; };
-		8698CFF22061A3930065AE20 /* MapController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapController.swift; sourceTree = "<group>"; };
-		8698CFF32061A3930065AE20 /* MapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
-		8698CFF52061A3930065AE20 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
-		8698CFF62061A3930065AE20 /* XibFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibFooterView.swift; sourceTree = "<group>"; };
-		8698CFF72061A3930065AE20 /* XibFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibFooterView.xib; sourceTree = "<group>"; };
-		8698CFF82061A3930065AE20 /* XibHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibHeaderView.swift; sourceTree = "<group>"; };
-		8698CFF92061A3930065AE20 /* XibHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibHeaderView.xib; sourceTree = "<group>"; };
-		8698CFFA2061A3930065AE20 /* XibTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibTableViewCell.swift; sourceTree = "<group>"; };
-		8698CFFB2061A3930065AE20 /* XibTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibTableViewCell.xib; sourceTree = "<group>"; };
-		8698CFFC2061A3930065AE20 /* XibViewsTableController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibViewsTableController.swift; sourceTree = "<group>"; };
-		8698CFFE2061A3930065AE20 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		8698CFFF2061A3930065AE20 /* XibView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibView.swift; sourceTree = "<group>"; };
-		8698D0002061A3930065AE20 /* XibView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibView.xib; sourceTree = "<group>"; };
-		8698D0022061A3930065AE20 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
-		8698D0032061A3930065AE20 /* NamedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamedViewController.swift; sourceTree = "<group>"; };
-		8698D0042061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboardIdentifier+Extensions.swift"; sourceTree = "<group>"; };
-		8698D0052061A3930065AE20 /* VCTest.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = VCTest.storyboard; sourceTree = "<group>"; };
-		8698D0062061A3930065AE20 /* VCViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VCViewController.swift; sourceTree = "<group>"; };
-		8698D0072061A3930065AE20 /* ViewControllerA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerA.swift; sourceTree = "<group>"; };
-		8698D0082061A3930065AE20 /* ViewControllerB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerB.swift; sourceTree = "<group>"; };
-		8698D0092061A3930065AE20 /* WipeTransitionAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WipeTransitionAnimator.swift; sourceTree = "<group>"; };
+        0E6E8C6C2112551200617815 /* ContainerViewController+ManagedChildren.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContainerViewController+ManagedChildren.swift"; sourceTree = "<group>"; };
+        0EC8025B209CE9C90051F732 /* Configurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configurable.swift; sourceTree = "<group>"; };
+        0ED9476220FD461300B642AB /* ContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerTests.swift; sourceTree = "<group>"; };
+        1D419DBC21235EE100B62D91 /* ManagedChild.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManagedChild.swift; sourceTree = "<group>"; };
+        8677313920601BB400C54343 /* UtiliKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UtiliKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+        8677314120601BB400C54343 /* UtiliKit-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UtiliKit-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+        8677315A20601DD800C54343 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        869826261FE87BFA0024B73D /* UtiliKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtiliKitTests.swift; sourceTree = "<group>"; };
+        869826271FE87BFA0024B73D /* DateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateTests.swift; sourceTree = "<group>"; };
+        8698CF9F20619EAD0065AE20 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        8698CFA020619EAD0065AE20 /* UtiliKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UtiliKit.h; sourceTree = "<group>"; };
+        8698CFA320619EAD0065AE20 /* ContainerTransitionContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerTransitionContext.swift; sourceTree = "<group>"; };
+        8698CFA420619EAD0065AE20 /* ContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewController.swift; sourceTree = "<group>"; };
+        8698CFA520619EAD0065AE20 /* ContainerViewControllerDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewControllerDelegate.swift; sourceTree = "<group>"; };
+        8698CFA620619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerViewControllerTransitionAnimator.swift; sourceTree = "<group>"; };
+        8698CFA820619EAD0065AE20 /* FileManager+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FileManager+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFA920619EAD0065AE20 /* UIView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFAB20619EAD0065AE20 /* MKMapView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MKMapView+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFAC20619EAD0065AE20 /* NibLoadable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibLoadable.swift; sourceTree = "<group>"; };
+        8698CFAD20619EAD0065AE20 /* ReuseIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReuseIdentifiable.swift; sourceTree = "<group>"; };
+        8698CFAE20619EAD0065AE20 /* StoryboardIdentifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryboardIdentifiable.swift; sourceTree = "<group>"; };
+        8698CFAF20619EAD0065AE20 /* UICollectionView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionView+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFB020619EAD0065AE20 /* UIStoryboard+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboard+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFB120619EAD0065AE20 /* UITableView+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFB320619EAD0065AE20 /* Date+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFB420619EAD0065AE20 /* TimelessDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimelessDate.swift; sourceTree = "<group>"; };
+        8698CFB620619EAD0065AE20 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
+        8698CFB720619EAD0065AE20 /* VersionConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VersionConfig.swift; sourceTree = "<group>"; };
+        8698CFD02061A19D0065AE20 /* UtiliKit-iOSExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "UtiliKit-iOSExample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+        8698CFE32061A3930065AE20 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+        8698CFE52061A3930065AE20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+        8698CFE72061A3930065AE20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+        8698CFE92061A3930065AE20 /* CollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewController.swift; sourceTree = "<group>"; };
+        8698CFEA2061A3930065AE20 /* ProgrammaticCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgrammaticCell.swift; sourceTree = "<group>"; };
+        8698CFEB2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgrammaticHeaderFooterView.swift; sourceTree = "<group>"; };
+        8698CFEC2061A3930065AE20 /* ProgrammaticViewsCollectionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgrammaticViewsCollectionController.swift; sourceTree = "<group>"; };
+        8698CFED2061A3930065AE20 /* ContainerExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContainerExampleViewController.swift; sourceTree = "<group>"; };
+        8698CFEE2061A3930065AE20 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+        8698CFEF2061A3930065AE20 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+        8698CFF12061A3930065AE20 /* CustomAnnotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomAnnotation.swift; sourceTree = "<group>"; };
+        8698CFF22061A3930065AE20 /* MapController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapController.swift; sourceTree = "<group>"; };
+        8698CFF32061A3930065AE20 /* MapViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
+        8698CFF52061A3930065AE20 /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
+        8698CFF62061A3930065AE20 /* XibFooterView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibFooterView.swift; sourceTree = "<group>"; };
+        8698CFF72061A3930065AE20 /* XibFooterView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibFooterView.xib; sourceTree = "<group>"; };
+        8698CFF82061A3930065AE20 /* XibHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibHeaderView.swift; sourceTree = "<group>"; };
+        8698CFF92061A3930065AE20 /* XibHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibHeaderView.xib; sourceTree = "<group>"; };
+        8698CFFA2061A3930065AE20 /* XibTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibTableViewCell.swift; sourceTree = "<group>"; };
+        8698CFFB2061A3930065AE20 /* XibTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibTableViewCell.xib; sourceTree = "<group>"; };
+        8698CFFC2061A3930065AE20 /* XibViewsTableController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibViewsTableController.swift; sourceTree = "<group>"; };
+        8698CFFE2061A3930065AE20 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+        8698CFFF2061A3930065AE20 /* XibView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XibView.swift; sourceTree = "<group>"; };
+        8698D0002061A3930065AE20 /* XibView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = XibView.xib; sourceTree = "<group>"; };
+        8698D0022061A3930065AE20 /* InitialViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InitialViewController.swift; sourceTree = "<group>"; };
+        8698D0032061A3930065AE20 /* NamedViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NamedViewController.swift; sourceTree = "<group>"; };
+        8698D0042061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIStoryboardIdentifier+Extensions.swift"; sourceTree = "<group>"; };
+        8698D0052061A3930065AE20 /* VCTest.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = VCTest.storyboard; sourceTree = "<group>"; };
+        8698D0062061A3930065AE20 /* VCViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VCViewController.swift; sourceTree = "<group>"; };
+        8698D0072061A3930065AE20 /* ViewControllerA.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerA.swift; sourceTree = "<group>"; };
+        8698D0082061A3930065AE20 /* ViewControllerB.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerB.swift; sourceTree = "<group>"; };
+        8698D0092061A3930065AE20 /* WipeTransitionAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WipeTransitionAnimator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		8677313520601BB400C54343 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8677313E20601BB400C54343 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8677314220601BB400C54343 /* UtiliKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8698CFCD2061A19D0065AE20 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1D419DBF21236CC300B62D91 /* UtiliKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        8677313520601BB400C54343 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        8677313E20601BB400C54343 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                8677314220601BB400C54343 /* UtiliKit.framework in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        8698CFCD2061A19D0065AE20 /* Frameworks */ = {
+            isa = PBXFrameworksBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                1D419DBF21236CC300B62D91 /* UtiliKit.framework in Frameworks */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		1D419DBE21236CC300B62D91 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		607FACC71AFB9204008FA782 = {
-			isa = PBXGroup;
-			children = (
-				8698CFCB2061A0FB0065AE20 /* Examples */,
-				8698CF9D20619EAD0065AE20 /* Sources */,
-				607FACE81AFB9204008FA782 /* Tests */,
-				607FACD11AFB9204008FA782 /* Products */,
-				1D419DBE21236CC300B62D91 /* Frameworks */,
-			);
-			sourceTree = "<group>";
-		};
-		607FACD11AFB9204008FA782 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				8677313920601BB400C54343 /* UtiliKit.framework */,
-				8677314120601BB400C54343 /* UtiliKit-iOSTests.xctest */,
-				8698CFD02061A19D0065AE20 /* UtiliKit-iOSExample.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		607FACE81AFB9204008FA782 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				869826271FE87BFA0024B73D /* DateTests.swift */,
-				869826261FE87BFA0024B73D /* UtiliKitTests.swift */,
-				0ED9476220FD461300B642AB /* ContainerTests.swift */,
-				8677315920601DD800C54343 /* Supporting Files */,
-			);
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		8677315920601DD800C54343 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				8677315A20601DD800C54343 /* Info.plist */,
-			);
-			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		8698CF9D20619EAD0065AE20 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				8698CF9E20619EAD0065AE20 /* Supporting Files */,
-				8698CFA120619EAD0065AE20 /* UtiliKit */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		8698CF9E20619EAD0065AE20 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				8698CF9F20619EAD0065AE20 /* Info.plist */,
-				8698CFA020619EAD0065AE20 /* UtiliKit.h */,
-			);
-			path = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		8698CFA120619EAD0065AE20 /* UtiliKit */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFA220619EAD0065AE20 /* Container */,
-				8698CFA720619EAD0065AE20 /* General */,
-				8698CFAA20619EAD0065AE20 /* Instantiation */,
-				8698CFB220619EAD0065AE20 /* TimelessDate */,
-				8698CFB520619EAD0065AE20 /* Version */,
-			);
-			path = UtiliKit;
-			sourceTree = "<group>";
-		};
-		8698CFA220619EAD0065AE20 /* Container */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFA320619EAD0065AE20 /* ContainerTransitionContext.swift */,
-				8698CFA420619EAD0065AE20 /* ContainerViewController.swift */,
-				0E6E8C6C2112551200617815 /* ContainerViewController+ManagedChildren.swift */,
-				8698CFA520619EAD0065AE20 /* ContainerViewControllerDelegate.swift */,
-				8698CFA620619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift */,
-				1D419DBC21235EE100B62D91 /* ManagedChild.swift */,
-			);
-			path = Container;
-			sourceTree = "<group>";
-		};
-		8698CFA720619EAD0065AE20 /* General */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFA820619EAD0065AE20 /* FileManager+Extensions.swift */,
-				8698CFA920619EAD0065AE20 /* UIView+Extensions.swift */,
-			);
-			path = General;
-			sourceTree = "<group>";
-		};
-		8698CFAA20619EAD0065AE20 /* Instantiation */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFAB20619EAD0065AE20 /* MKMapView+Extensions.swift */,
-				8698CFAC20619EAD0065AE20 /* NibLoadable.swift */,
-				8698CFAD20619EAD0065AE20 /* ReuseIdentifiable.swift */,
-				8698CFAE20619EAD0065AE20 /* StoryboardIdentifiable.swift */,
-				0EC8025B209CE9C90051F732 /* Configurable.swift */,
-				8698CFAF20619EAD0065AE20 /* UICollectionView+Extensions.swift */,
-				8698CFB020619EAD0065AE20 /* UIStoryboard+Extensions.swift */,
-				8698CFB120619EAD0065AE20 /* UITableView+Extensions.swift */,
-			);
-			path = Instantiation;
-			sourceTree = "<group>";
-		};
-		8698CFB220619EAD0065AE20 /* TimelessDate */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFB320619EAD0065AE20 /* Date+Extensions.swift */,
-				8698CFB420619EAD0065AE20 /* TimelessDate.swift */,
-			);
-			path = TimelessDate;
-			sourceTree = "<group>";
-		};
-		8698CFB520619EAD0065AE20 /* Version */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFB620619EAD0065AE20 /* Bundle+Extensions.swift */,
-				8698CFB720619EAD0065AE20 /* VersionConfig.swift */,
-			);
-			path = Version;
-			sourceTree = "<group>";
-		};
-		8698CFCB2061A0FB0065AE20 /* Examples */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFE22061A3930065AE20 /* UtiliKit-iOSExample */,
-			);
-			path = Examples;
-			sourceTree = "<group>";
-		};
-		8698CFE22061A3930065AE20 /* UtiliKit-iOSExample */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFE32061A3930065AE20 /* AppDelegate.swift */,
-				8698CFE42061A3930065AE20 /* LaunchScreen.xib */,
-				8698CFE62061A3930065AE20 /* Main.storyboard */,
-				8698CFE82061A3930065AE20 /* Collection */,
-				8698CFED2061A3930065AE20 /* ContainerExampleViewController.swift */,
-				8698CFEE2061A3930065AE20 /* Images.xcassets */,
-				8698CFEF2061A3930065AE20 /* Info.plist */,
-				8698CFF02061A3930065AE20 /* Map */,
-				8698CFF42061A3930065AE20 /* Table */,
-				8698CFFD2061A3930065AE20 /* View */,
-				8698D0012061A3930065AE20 /* ViewController */,
-				8698D0072061A3930065AE20 /* ViewControllerA.swift */,
-				8698D0082061A3930065AE20 /* ViewControllerB.swift */,
-				8698D0092061A3930065AE20 /* WipeTransitionAnimator.swift */,
-			);
-			path = "UtiliKit-iOSExample";
-			sourceTree = "<group>";
-		};
-		8698CFE82061A3930065AE20 /* Collection */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFE92061A3930065AE20 /* CollectionViewController.swift */,
-				8698CFEA2061A3930065AE20 /* ProgrammaticCell.swift */,
-				8698CFEB2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift */,
-				8698CFEC2061A3930065AE20 /* ProgrammaticViewsCollectionController.swift */,
-			);
-			path = Collection;
-			sourceTree = "<group>";
-		};
-		8698CFF02061A3930065AE20 /* Map */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFF12061A3930065AE20 /* CustomAnnotation.swift */,
-				8698CFF22061A3930065AE20 /* MapController.swift */,
-				8698CFF32061A3930065AE20 /* MapViewController.swift */,
-			);
-			path = Map;
-			sourceTree = "<group>";
-		};
-		8698CFF42061A3930065AE20 /* Table */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFF52061A3930065AE20 /* TableViewController.swift */,
-				8698CFF62061A3930065AE20 /* XibFooterView.swift */,
-				8698CFF72061A3930065AE20 /* XibFooterView.xib */,
-				8698CFF82061A3930065AE20 /* XibHeaderView.swift */,
-				8698CFF92061A3930065AE20 /* XibHeaderView.xib */,
-				8698CFFA2061A3930065AE20 /* XibTableViewCell.swift */,
-				8698CFFB2061A3930065AE20 /* XibTableViewCell.xib */,
-				8698CFFC2061A3930065AE20 /* XibViewsTableController.swift */,
-			);
-			path = Table;
-			sourceTree = "<group>";
-		};
-		8698CFFD2061A3930065AE20 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				8698CFFE2061A3930065AE20 /* ViewController.swift */,
-				8698CFFF2061A3930065AE20 /* XibView.swift */,
-				8698D0002061A3930065AE20 /* XibView.xib */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		8698D0012061A3930065AE20 /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-				8698D0022061A3930065AE20 /* InitialViewController.swift */,
-				8698D0032061A3930065AE20 /* NamedViewController.swift */,
-				8698D0042061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift */,
-				8698D0052061A3930065AE20 /* VCTest.storyboard */,
-				8698D0062061A3930065AE20 /* VCViewController.swift */,
-			);
-			path = ViewController;
-			sourceTree = "<group>";
-		};
+        1D419DBE21236CC300B62D91 /* Frameworks */ = {
+            isa = PBXGroup;
+            children = (
+            );
+            name = Frameworks;
+            sourceTree = "<group>";
+        };
+        607FACC71AFB9204008FA782 = {
+            isa = PBXGroup;
+            children = (
+                8698CFCB2061A0FB0065AE20 /* Examples */,
+                8698CF9D20619EAD0065AE20 /* Sources */,
+                607FACE81AFB9204008FA782 /* Tests */,
+                607FACD11AFB9204008FA782 /* Products */,
+                1D419DBE21236CC300B62D91 /* Frameworks */,
+            );
+            sourceTree = "<group>";
+        };
+        607FACD11AFB9204008FA782 /* Products */ = {
+            isa = PBXGroup;
+            children = (
+                8677313920601BB400C54343 /* UtiliKit.framework */,
+                8677314120601BB400C54343 /* UtiliKit-iOSTests.xctest */,
+                8698CFD02061A19D0065AE20 /* UtiliKit-iOSExample.app */,
+            );
+            name = Products;
+            sourceTree = "<group>";
+        };
+        607FACE81AFB9204008FA782 /* Tests */ = {
+            isa = PBXGroup;
+            children = (
+                869826271FE87BFA0024B73D /* DateTests.swift */,
+                869826261FE87BFA0024B73D /* UtiliKitTests.swift */,
+                0ED9476220FD461300B642AB /* ContainerTests.swift */,
+                8677315920601DD800C54343 /* Supporting Files */,
+            );
+            path = Tests;
+            sourceTree = "<group>";
+        };
+        8677315920601DD800C54343 /* Supporting Files */ = {
+            isa = PBXGroup;
+            children = (
+                8677315A20601DD800C54343 /* Info.plist */,
+            );
+            path = "Supporting Files";
+            sourceTree = "<group>";
+        };
+        8698CF9D20619EAD0065AE20 /* Sources */ = {
+            isa = PBXGroup;
+            children = (
+                8698CF9E20619EAD0065AE20 /* Supporting Files */,
+                8698CFA120619EAD0065AE20 /* UtiliKit */,
+            );
+            path = Sources;
+            sourceTree = "<group>";
+        };
+        8698CF9E20619EAD0065AE20 /* Supporting Files */ = {
+            isa = PBXGroup;
+            children = (
+                8698CF9F20619EAD0065AE20 /* Info.plist */,
+                8698CFA020619EAD0065AE20 /* UtiliKit.h */,
+            );
+            path = "Supporting Files";
+            sourceTree = "<group>";
+        };
+        8698CFA120619EAD0065AE20 /* UtiliKit */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFA220619EAD0065AE20 /* Container */,
+                8698CFA720619EAD0065AE20 /* General */,
+                8698CFAA20619EAD0065AE20 /* Instantiation */,
+                8698CFB220619EAD0065AE20 /* TimelessDate */,
+                8698CFB520619EAD0065AE20 /* Version */,
+            );
+            path = UtiliKit;
+            sourceTree = "<group>";
+        };
+        8698CFA220619EAD0065AE20 /* Container */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFA320619EAD0065AE20 /* ContainerTransitionContext.swift */,
+                8698CFA420619EAD0065AE20 /* ContainerViewController.swift */,
+                0E6E8C6C2112551200617815 /* ContainerViewController+ManagedChildren.swift */,
+                8698CFA520619EAD0065AE20 /* ContainerViewControllerDelegate.swift */,
+                8698CFA620619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift */,
+                1D419DBC21235EE100B62D91 /* ManagedChild.swift */,
+            );
+            path = Container;
+            sourceTree = "<group>";
+        };
+        8698CFA720619EAD0065AE20 /* General */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFA820619EAD0065AE20 /* FileManager+Extensions.swift */,
+                8698CFA920619EAD0065AE20 /* UIView+Extensions.swift */,
+            );
+            path = General;
+            sourceTree = "<group>";
+        };
+        8698CFAA20619EAD0065AE20 /* Instantiation */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFAB20619EAD0065AE20 /* MKMapView+Extensions.swift */,
+                8698CFAC20619EAD0065AE20 /* NibLoadable.swift */,
+                8698CFAD20619EAD0065AE20 /* ReuseIdentifiable.swift */,
+                8698CFAE20619EAD0065AE20 /* StoryboardIdentifiable.swift */,
+                0EC8025B209CE9C90051F732 /* Configurable.swift */,
+                8698CFAF20619EAD0065AE20 /* UICollectionView+Extensions.swift */,
+                8698CFB020619EAD0065AE20 /* UIStoryboard+Extensions.swift */,
+                8698CFB120619EAD0065AE20 /* UITableView+Extensions.swift */,
+            );
+            path = Instantiation;
+            sourceTree = "<group>";
+        };
+        8698CFB220619EAD0065AE20 /* TimelessDate */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFB320619EAD0065AE20 /* Date+Extensions.swift */,
+                8698CFB420619EAD0065AE20 /* TimelessDate.swift */,
+            );
+            path = TimelessDate;
+            sourceTree = "<group>";
+        };
+        8698CFB520619EAD0065AE20 /* Version */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFB620619EAD0065AE20 /* Bundle+Extensions.swift */,
+                8698CFB720619EAD0065AE20 /* VersionConfig.swift */,
+            );
+            path = Version;
+            sourceTree = "<group>";
+        };
+        8698CFCB2061A0FB0065AE20 /* Examples */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFE22061A3930065AE20 /* UtiliKit-iOSExample */,
+            );
+            path = Examples;
+            sourceTree = "<group>";
+        };
+        8698CFE22061A3930065AE20 /* UtiliKit-iOSExample */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFE32061A3930065AE20 /* AppDelegate.swift */,
+                8698CFE42061A3930065AE20 /* LaunchScreen.xib */,
+                8698CFE62061A3930065AE20 /* Main.storyboard */,
+                8698CFE82061A3930065AE20 /* Collection */,
+                8698CFED2061A3930065AE20 /* ContainerExampleViewController.swift */,
+                8698CFEE2061A3930065AE20 /* Images.xcassets */,
+                8698CFEF2061A3930065AE20 /* Info.plist */,
+                8698CFF02061A3930065AE20 /* Map */,
+                8698CFF42061A3930065AE20 /* Table */,
+                8698CFFD2061A3930065AE20 /* View */,
+                8698D0012061A3930065AE20 /* ViewController */,
+                8698D0072061A3930065AE20 /* ViewControllerA.swift */,
+                8698D0082061A3930065AE20 /* ViewControllerB.swift */,
+                8698D0092061A3930065AE20 /* WipeTransitionAnimator.swift */,
+            );
+            path = "UtiliKit-iOSExample";
+            sourceTree = "<group>";
+        };
+        8698CFE82061A3930065AE20 /* Collection */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFE92061A3930065AE20 /* CollectionViewController.swift */,
+                8698CFEA2061A3930065AE20 /* ProgrammaticCell.swift */,
+                8698CFEB2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift */,
+                8698CFEC2061A3930065AE20 /* ProgrammaticViewsCollectionController.swift */,
+            );
+            path = Collection;
+            sourceTree = "<group>";
+        };
+        8698CFF02061A3930065AE20 /* Map */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFF12061A3930065AE20 /* CustomAnnotation.swift */,
+                8698CFF22061A3930065AE20 /* MapController.swift */,
+                8698CFF32061A3930065AE20 /* MapViewController.swift */,
+            );
+            path = Map;
+            sourceTree = "<group>";
+        };
+        8698CFF42061A3930065AE20 /* Table */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFF52061A3930065AE20 /* TableViewController.swift */,
+                8698CFF62061A3930065AE20 /* XibFooterView.swift */,
+                8698CFF72061A3930065AE20 /* XibFooterView.xib */,
+                8698CFF82061A3930065AE20 /* XibHeaderView.swift */,
+                8698CFF92061A3930065AE20 /* XibHeaderView.xib */,
+                8698CFFA2061A3930065AE20 /* XibTableViewCell.swift */,
+                8698CFFB2061A3930065AE20 /* XibTableViewCell.xib */,
+                8698CFFC2061A3930065AE20 /* XibViewsTableController.swift */,
+            );
+            path = Table;
+            sourceTree = "<group>";
+        };
+        8698CFFD2061A3930065AE20 /* View */ = {
+            isa = PBXGroup;
+            children = (
+                8698CFFE2061A3930065AE20 /* ViewController.swift */,
+                8698CFFF2061A3930065AE20 /* XibView.swift */,
+                8698D0002061A3930065AE20 /* XibView.xib */,
+            );
+            path = View;
+            sourceTree = "<group>";
+        };
+        8698D0012061A3930065AE20 /* ViewController */ = {
+            isa = PBXGroup;
+            children = (
+                8698D0022061A3930065AE20 /* InitialViewController.swift */,
+                8698D0032061A3930065AE20 /* NamedViewController.swift */,
+                8698D0042061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift */,
+                8698D0052061A3930065AE20 /* VCTest.storyboard */,
+                8698D0062061A3930065AE20 /* VCViewController.swift */,
+            );
+            path = ViewController;
+            sourceTree = "<group>";
+        };
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		8677313620601BB400C54343 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8698CFB920619EAD0065AE20 /* UtiliKit.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        8677313620601BB400C54343 /* Headers */ = {
+            isa = PBXHeadersBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                8698CFB920619EAD0065AE20 /* UtiliKit.h in Headers */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		8677313820601BB400C54343 /* UtiliKit-iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8677315420601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOS" */;
-			buildPhases = (
-				8677313420601BB400C54343 /* Sources */,
-				8677313520601BB400C54343 /* Frameworks */,
-				8677313620601BB400C54343 /* Headers */,
-				8677313720601BB400C54343 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "UtiliKit-iOS";
-			productName = "UtiliKit-iOS";
-			productReference = 8677313920601BB400C54343 /* UtiliKit.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		8677314020601BB400C54343 /* UtiliKit-iOSTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8677315620601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSTests" */;
-			buildPhases = (
-				8677313D20601BB400C54343 /* Sources */,
-				8677313E20601BB400C54343 /* Frameworks */,
-				8677313F20601BB400C54343 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				8677314420601BB400C54343 /* PBXTargetDependency */,
-			);
-			name = "UtiliKit-iOSTests";
-			productName = "UtiliKit-iOSTests";
-			productReference = 8677314120601BB400C54343 /* UtiliKit-iOSTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		8698CFCF2061A19D0065AE20 /* UtiliKit-iOSExample */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8698CFDF2061A19D0065AE20 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSExample" */;
-			buildPhases = (
-				8698CFCC2061A19D0065AE20 /* Sources */,
-				8698CFCD2061A19D0065AE20 /* Frameworks */,
-				8698CFCE2061A19D0065AE20 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "UtiliKit-iOSExample";
-			productName = "UtiliKit-iOSExample";
-			productReference = 8698CFD02061A19D0065AE20 /* UtiliKit-iOSExample.app */;
-			productType = "com.apple.product-type.application";
-		};
+        8677313820601BB400C54343 /* UtiliKit-iOS */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 8677315420601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOS" */;
+            buildPhases = (
+                8677313420601BB400C54343 /* Sources */,
+                8677313520601BB400C54343 /* Frameworks */,
+                8677313620601BB400C54343 /* Headers */,
+                8677313720601BB400C54343 /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+            );
+            name = "UtiliKit-iOS";
+            productName = "UtiliKit-iOS";
+            productReference = 8677313920601BB400C54343 /* UtiliKit.framework */;
+            productType = "com.apple.product-type.framework";
+        };
+        8677314020601BB400C54343 /* UtiliKit-iOSTests */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 8677315620601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSTests" */;
+            buildPhases = (
+                8677313D20601BB400C54343 /* Sources */,
+                8677313E20601BB400C54343 /* Frameworks */,
+                8677313F20601BB400C54343 /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+                8677314420601BB400C54343 /* PBXTargetDependency */,
+            );
+            name = "UtiliKit-iOSTests";
+            productName = "UtiliKit-iOSTests";
+            productReference = 8677314120601BB400C54343 /* UtiliKit-iOSTests.xctest */;
+            productType = "com.apple.product-type.bundle.unit-test";
+        };
+        8698CFCF2061A19D0065AE20 /* UtiliKit-iOSExample */ = {
+            isa = PBXNativeTarget;
+            buildConfigurationList = 8698CFDF2061A19D0065AE20 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSExample" */;
+            buildPhases = (
+                8698CFCC2061A19D0065AE20 /* Sources */,
+                8698CFCD2061A19D0065AE20 /* Frameworks */,
+                8698CFCE2061A19D0065AE20 /* Resources */,
+            );
+            buildRules = (
+            );
+            dependencies = (
+            );
+            name = "UtiliKit-iOSExample";
+            productName = "UtiliKit-iOSExample";
+            productReference = 8698CFD02061A19D0065AE20 /* UtiliKit-iOSExample.app */;
+            productType = "com.apple.product-type.application";
+        };
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		607FACC81AFB9204008FA782 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = CocoaPods;
-				TargetAttributes = {
-					8677313820601BB400C54343 = {
-						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Automatic;
-					};
-					8677314020601BB400C54343 = {
-						CreatedOnToolsVersion = 9.2;
-						ProvisioningStyle = Automatic;
-					};
-					8698CFCF2061A19D0065AE20 = {
-						CreatedOnToolsVersion = 9.2;
-						DevelopmentTeam = 2UAV38D2MU;
-						ProvisioningStyle = Automatic;
-					};
-				};
-			};
-			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "UtiliKit" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-				Base,
-			);
-			mainGroup = 607FACC71AFB9204008FA782;
-			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				8677313820601BB400C54343 /* UtiliKit-iOS */,
-				8677314020601BB400C54343 /* UtiliKit-iOSTests */,
-				8698CFCF2061A19D0065AE20 /* UtiliKit-iOSExample */,
-			);
-		};
+        607FACC81AFB9204008FA782 /* Project object */ = {
+            isa = PBXProject;
+            attributes = {
+                LastSwiftUpdateCheck = 0920;
+                LastUpgradeCheck = 0930;
+                ORGANIZATIONNAME = CocoaPods;
+                TargetAttributes = {
+                    8677313820601BB400C54343 = {
+                        CreatedOnToolsVersion = 9.2;
+                        ProvisioningStyle = Automatic;
+                    };
+                    8677314020601BB400C54343 = {
+                        CreatedOnToolsVersion = 9.2;
+                        ProvisioningStyle = Automatic;
+                    };
+                    8698CFCF2061A19D0065AE20 = {
+                        CreatedOnToolsVersion = 9.2;
+                        DevelopmentTeam = 2UAV38D2MU;
+                        ProvisioningStyle = Automatic;
+                    };
+                };
+            };
+            buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "UtiliKit" */;
+            compatibilityVersion = "Xcode 3.2";
+            developmentRegion = English;
+            hasScannedForEncodings = 0;
+            knownRegions = (
+                en,
+                Base,
+            );
+            mainGroup = 607FACC71AFB9204008FA782;
+            productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
+            projectDirPath = "";
+            projectRoot = "";
+            targets = (
+                8677313820601BB400C54343 /* UtiliKit-iOS */,
+                8677314020601BB400C54343 /* UtiliKit-iOSTests */,
+                8698CFCF2061A19D0065AE20 /* UtiliKit-iOSExample */,
+            );
+        };
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		8677313720601BB400C54343 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8677313F20601BB400C54343 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8698CFCE2061A19D0065AE20 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8698D01D2061A3930065AE20 /* XibTableViewCell.xib in Resources */,
-				8698D0212061A3930065AE20 /* XibView.xib in Resources */,
-				8698D01B2061A3930065AE20 /* XibHeaderView.xib in Resources */,
-				8698D0122061A3930065AE20 /* Images.xcassets in Resources */,
-				8698D00B2061A3930065AE20 /* LaunchScreen.xib in Resources */,
-				8698D0192061A3930065AE20 /* XibFooterView.xib in Resources */,
-				8698D0252061A3930065AE20 /* VCTest.storyboard in Resources */,
-				8698D00C2061A3930065AE20 /* Main.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        8677313720601BB400C54343 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        8677313F20601BB400C54343 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        8698CFCE2061A19D0065AE20 /* Resources */ = {
+            isa = PBXResourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                8698D01D2061A3930065AE20 /* XibTableViewCell.xib in Resources */,
+                8698D0212061A3930065AE20 /* XibView.xib in Resources */,
+                8698D01B2061A3930065AE20 /* XibHeaderView.xib in Resources */,
+                8698D0122061A3930065AE20 /* Images.xcassets in Resources */,
+                8698D00B2061A3930065AE20 /* LaunchScreen.xib in Resources */,
+                8698D0192061A3930065AE20 /* XibFooterView.xib in Resources */,
+                8698D0252061A3930065AE20 /* VCTest.storyboard in Resources */,
+                8698D00C2061A3930065AE20 /* Main.storyboard in Resources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		8677313420601BB400C54343 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8698CFC020619EAD0065AE20 /* MKMapView+Extensions.swift in Sources */,
-				8698CFC120619EAD0065AE20 /* NibLoadable.swift in Sources */,
-				8698CFBF20619EAD0065AE20 /* UIView+Extensions.swift in Sources */,
-				8698CFBB20619EAD0065AE20 /* ContainerViewController.swift in Sources */,
-				8698CFCA20619EAD0065AE20 /* VersionConfig.swift in Sources */,
-				8698CFC420619EAD0065AE20 /* UICollectionView+Extensions.swift in Sources */,
-				0E6E8C6D2112551200617815 /* ContainerViewController+ManagedChildren.swift in Sources */,
-				0EC8025C209CE9C90051F732 /* Configurable.swift in Sources */,
-				8698CFC820619EAD0065AE20 /* TimelessDate.swift in Sources */,
-				8698CFC320619EAD0065AE20 /* StoryboardIdentifiable.swift in Sources */,
-				8698CFC920619EAD0065AE20 /* Bundle+Extensions.swift in Sources */,
-				8698CFC520619EAD0065AE20 /* UIStoryboard+Extensions.swift in Sources */,
-				8698CFC220619EAD0065AE20 /* ReuseIdentifiable.swift in Sources */,
-				8698CFC620619EAD0065AE20 /* UITableView+Extensions.swift in Sources */,
-				8698CFC720619EAD0065AE20 /* Date+Extensions.swift in Sources */,
-				8698CFBA20619EAD0065AE20 /* ContainerTransitionContext.swift in Sources */,
-				8698CFBE20619EAD0065AE20 /* FileManager+Extensions.swift in Sources */,
-				8698CFBD20619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift in Sources */,
-				1D419DBD21235EE100B62D91 /* ManagedChild.swift in Sources */,
-				8698CFBC20619EAD0065AE20 /* ContainerViewControllerDelegate.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8677313D20601BB400C54343 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0ED9476420FD473700B642AB /* ContainerTests.swift in Sources */,
-				8677315720601D1A00C54343 /* UtiliKitTests.swift in Sources */,
-				8677315820601D1A00C54343 /* DateTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8698CFCC2061A19D0065AE20 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8698D0232061A3930065AE20 /* NamedViewController.swift in Sources */,
-				8698D01F2061A3930065AE20 /* ViewController.swift in Sources */,
-				8698D0152061A3930065AE20 /* MapController.swift in Sources */,
-				8698D01C2061A3930065AE20 /* XibTableViewCell.swift in Sources */,
-				8698D00E2061A3930065AE20 /* ProgrammaticCell.swift in Sources */,
-				8698D00D2061A3930065AE20 /* CollectionViewController.swift in Sources */,
-				8698D0172061A3930065AE20 /* TableViewController.swift in Sources */,
-				8698D0202061A3930065AE20 /* XibView.swift in Sources */,
-				8698D0292061A3930065AE20 /* WipeTransitionAnimator.swift in Sources */,
-				8698D0222061A3930065AE20 /* InitialViewController.swift in Sources */,
-				8698D0262061A3930065AE20 /* VCViewController.swift in Sources */,
-				8698D00F2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift in Sources */,
-				8698D01A2061A3930065AE20 /* XibHeaderView.swift in Sources */,
-				8698D01E2061A3930065AE20 /* XibViewsTableController.swift in Sources */,
-				8698D0162061A3930065AE20 /* MapViewController.swift in Sources */,
-				8698D0102061A3930065AE20 /* ProgrammaticViewsCollectionController.swift in Sources */,
-				8698D00A2061A3930065AE20 /* AppDelegate.swift in Sources */,
-				8698D0182061A3930065AE20 /* XibFooterView.swift in Sources */,
-				8698D0112061A3930065AE20 /* ContainerExampleViewController.swift in Sources */,
-				8698D0242061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift in Sources */,
-				8698D0272061A3930065AE20 /* ViewControllerA.swift in Sources */,
-				8698D0142061A3930065AE20 /* CustomAnnotation.swift in Sources */,
-				8698D0282061A3930065AE20 /* ViewControllerB.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+        8677313420601BB400C54343 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                8698CFC020619EAD0065AE20 /* MKMapView+Extensions.swift in Sources */,
+                8698CFC120619EAD0065AE20 /* NibLoadable.swift in Sources */,
+                8698CFBF20619EAD0065AE20 /* UIView+Extensions.swift in Sources */,
+                8698CFBB20619EAD0065AE20 /* ContainerViewController.swift in Sources */,
+                8698CFCA20619EAD0065AE20 /* VersionConfig.swift in Sources */,
+                8698CFC420619EAD0065AE20 /* UICollectionView+Extensions.swift in Sources */,
+                0E6E8C6D2112551200617815 /* ContainerViewController+ManagedChildren.swift in Sources */,
+                0EC8025C209CE9C90051F732 /* Configurable.swift in Sources */,
+                8698CFC820619EAD0065AE20 /* TimelessDate.swift in Sources */,
+                8698CFC320619EAD0065AE20 /* StoryboardIdentifiable.swift in Sources */,
+                8698CFC920619EAD0065AE20 /* Bundle+Extensions.swift in Sources */,
+                8698CFC520619EAD0065AE20 /* UIStoryboard+Extensions.swift in Sources */,
+                8698CFC220619EAD0065AE20 /* ReuseIdentifiable.swift in Sources */,
+                8698CFC620619EAD0065AE20 /* UITableView+Extensions.swift in Sources */,
+                8698CFC720619EAD0065AE20 /* Date+Extensions.swift in Sources */,
+                8698CFBA20619EAD0065AE20 /* ContainerTransitionContext.swift in Sources */,
+                8698CFBE20619EAD0065AE20 /* FileManager+Extensions.swift in Sources */,
+                8698CFBD20619EAD0065AE20 /* ContainerViewControllerTransitionAnimator.swift in Sources */,
+                1D419DBD21235EE100B62D91 /* ManagedChild.swift in Sources */,
+                8698CFBC20619EAD0065AE20 /* ContainerViewControllerDelegate.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        8677313D20601BB400C54343 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                0ED9476420FD473700B642AB /* ContainerTests.swift in Sources */,
+                8677315720601D1A00C54343 /* UtiliKitTests.swift in Sources */,
+                8677315820601D1A00C54343 /* DateTests.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
+        8698CFCC2061A19D0065AE20 /* Sources */ = {
+            isa = PBXSourcesBuildPhase;
+            buildActionMask = 2147483647;
+            files = (
+                8698D0232061A3930065AE20 /* NamedViewController.swift in Sources */,
+                8698D01F2061A3930065AE20 /* ViewController.swift in Sources */,
+                8698D0152061A3930065AE20 /* MapController.swift in Sources */,
+                8698D01C2061A3930065AE20 /* XibTableViewCell.swift in Sources */,
+                8698D00E2061A3930065AE20 /* ProgrammaticCell.swift in Sources */,
+                8698D00D2061A3930065AE20 /* CollectionViewController.swift in Sources */,
+                8698D0172061A3930065AE20 /* TableViewController.swift in Sources */,
+                8698D0202061A3930065AE20 /* XibView.swift in Sources */,
+                8698D0292061A3930065AE20 /* WipeTransitionAnimator.swift in Sources */,
+                8698D0222061A3930065AE20 /* InitialViewController.swift in Sources */,
+                8698D0262061A3930065AE20 /* VCViewController.swift in Sources */,
+                8698D00F2061A3930065AE20 /* ProgrammaticHeaderFooterView.swift in Sources */,
+                8698D01A2061A3930065AE20 /* XibHeaderView.swift in Sources */,
+                8698D01E2061A3930065AE20 /* XibViewsTableController.swift in Sources */,
+                8698D0162061A3930065AE20 /* MapViewController.swift in Sources */,
+                8698D0102061A3930065AE20 /* ProgrammaticViewsCollectionController.swift in Sources */,
+                8698D00A2061A3930065AE20 /* AppDelegate.swift in Sources */,
+                8698D0182061A3930065AE20 /* XibFooterView.swift in Sources */,
+                8698D0112061A3930065AE20 /* ContainerExampleViewController.swift in Sources */,
+                8698D0242061A3930065AE20 /* UIStoryboardIdentifier+Extensions.swift in Sources */,
+                8698D0272061A3930065AE20 /* ViewControllerA.swift in Sources */,
+                8698D0142061A3930065AE20 /* CustomAnnotation.swift in Sources */,
+                8698D0282061A3930065AE20 /* ViewControllerB.swift in Sources */,
+            );
+            runOnlyForDeploymentPostprocessing = 0;
+        };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		8677314420601BB400C54343 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8677313820601BB400C54343 /* UtiliKit-iOS */;
-			targetProxy = 8677314320601BB400C54343 /* PBXContainerItemProxy */;
-		};
+        8677314420601BB400C54343 /* PBXTargetDependency */ = {
+            isa = PBXTargetDependency;
+            target = 8677313820601BB400C54343 /* UtiliKit-iOS */;
+            targetProxy = 8677314320601BB400C54343 /* PBXContainerItemProxy */;
+        };
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		8698CFE42061A3930065AE20 /* LaunchScreen.xib */ = {
-			isa = PBXVariantGroup;
-			children = (
-				8698CFE52061A3930065AE20 /* Base */,
-			);
-			name = LaunchScreen.xib;
-			sourceTree = "<group>";
-		};
-		8698CFE62061A3930065AE20 /* Main.storyboard */ = {
-			isa = PBXVariantGroup;
-			children = (
-				8698CFE72061A3930065AE20 /* Base */,
-			);
-			name = Main.storyboard;
-			sourceTree = "<group>";
-		};
+        8698CFE42061A3930065AE20 /* LaunchScreen.xib */ = {
+            isa = PBXVariantGroup;
+            children = (
+                8698CFE52061A3930065AE20 /* Base */,
+            );
+            name = LaunchScreen.xib;
+            sourceTree = "<group>";
+        };
+        8698CFE62061A3930065AE20 /* Main.storyboard */ = {
+            isa = PBXVariantGroup;
+            children = (
+                8698CFE72061A3930065AE20 /* Base */,
+            );
+            name = Main.storyboard;
+            sourceTree = "<group>";
+        };
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		607FACED1AFB9204008FA782 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_TESTABILITY = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				VERSION = 1.3.0;
-			};
-			name = Debug;
-		};
-		607FACEE1AFB9204008FA782 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_COMMA = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
-				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
-				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
-				CLANG_WARN_STRICT_PROTOTYPES = YES;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_NS_ASSERTIONS = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				VALIDATE_PRODUCT = YES;
-				VERSION = 1.3.0;
-			};
-			name = Release;
-		};
-		8677315020601BB400C54343 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOS";
-				PRODUCT_NAME = UtiliKit;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSION = 1.2.1;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		8677315120601BB400C54343 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOS";
-				PRODUCT_NAME = UtiliKit;
-				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSION = 1.2.1;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		8677315220601BB400C54343 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSTests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSION = 1.2.1;
-			};
-			name = Debug;
-		};
-		8677315320601BB400C54343 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSTests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSION = 1.2.1;
-			};
-			name = Release;
-		};
-		8698CFE02061A19D0065AE20 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 2UAV38D2MU;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Examples/UtiliKit-iOSExample/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSExample";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSION = 1.2.1;
-			};
-			name = Debug;
-		};
-		8698CFE12061A19D0065AE20 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 2UAV38D2MU;
-				GCC_C_LANGUAGE_STANDARD = gnu11;
-				INFOPLIST_FILE = "Examples/UtiliKit-iOSExample/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSExample";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSION = 1.2.1;
-			};
-			name = Release;
-		};
+        607FACED1AFB9204008FA782 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+                CLANG_CXX_LIBRARY = "libc++";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                "CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                ENABLE_TESTABILITY = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu99;
+                GCC_DYNAMIC_NO_PIC = NO;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_OPTIMIZATION_LEVEL = 0;
+                GCC_PREPROCESSOR_DEFINITIONS = (
+                    "DEBUG=1",
+                    "$(inherited)",
+                );
+                GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+                MTL_ENABLE_DEBUG_INFO = YES;
+                ONLY_ACTIVE_ARCH = YES;
+                SDKROOT = iphoneos;
+                SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+                VERSION = 1.3.0;
+            };
+            name = Debug;
+        };
+        607FACEE1AFB9204008FA782 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ALWAYS_SEARCH_USER_PATHS = NO;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+                CLANG_CXX_LIBRARY = "libc++";
+                CLANG_ENABLE_MODULES = YES;
+                CLANG_ENABLE_OBJC_ARC = YES;
+                CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+                CLANG_WARN_BOOL_CONVERSION = YES;
+                CLANG_WARN_COMMA = YES;
+                CLANG_WARN_CONSTANT_CONVERSION = YES;
+                CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+                CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+                CLANG_WARN_EMPTY_BODY = YES;
+                CLANG_WARN_ENUM_CONVERSION = YES;
+                CLANG_WARN_INFINITE_RECURSION = YES;
+                CLANG_WARN_INT_CONVERSION = YES;
+                CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+                CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+                CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+                CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+                CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+                CLANG_WARN_STRICT_PROTOTYPES = YES;
+                CLANG_WARN_SUSPICIOUS_MOVE = YES;
+                CLANG_WARN_UNREACHABLE_CODE = YES;
+                CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+                "CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+                COPY_PHASE_STRIP = NO;
+                DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+                ENABLE_NS_ASSERTIONS = NO;
+                ENABLE_STRICT_OBJC_MSGSEND = YES;
+                GCC_C_LANGUAGE_STANDARD = gnu99;
+                GCC_NO_COMMON_BLOCKS = YES;
+                GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+                GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+                GCC_WARN_UNDECLARED_SELECTOR = YES;
+                GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+                GCC_WARN_UNUSED_FUNCTION = YES;
+                GCC_WARN_UNUSED_VARIABLE = YES;
+                IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+                MTL_ENABLE_DEBUG_INFO = NO;
+                SDKROOT = iphoneos;
+                SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+                VALIDATE_PRODUCT = YES;
+                VERSION = 1.3.0;
+            };
+            name = Release;
+        };
+        8677315020601BB400C54343 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                APPLICATION_EXTENSION_API_ONLY = YES;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CODE_SIGN_IDENTITY = "";
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEBUG_INFORMATION_FORMAT = dwarf;
+                DEFINES_MODULE = YES;
+                DYLIB_COMPATIBILITY_VERSION = 1;
+                DYLIB_CURRENT_VERSION = 1;
+                DYLIB_INSTALL_NAME_BASE = "@rpath";
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
+                INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+                IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+                PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOS";
+                PRODUCT_NAME = UtiliKit;
+                SKIP_INSTALL = YES;
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                SWIFT_VERSION = 4.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                VERSION = 1.2.1;
+                VERSIONING_SYSTEM = "apple-generic";
+                VERSION_INFO_PREFIX = "";
+            };
+            name = Debug;
+        };
+        8677315120601BB400C54343 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                APPLICATION_EXTENSION_API_ONLY = YES;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CODE_SIGN_IDENTITY = "";
+                CODE_SIGN_STYLE = Automatic;
+                CURRENT_PROJECT_VERSION = 1;
+                DEFINES_MODULE = YES;
+                DYLIB_COMPATIBILITY_VERSION = 1;
+                DYLIB_CURRENT_VERSION = 1;
+                DYLIB_INSTALL_NAME_BASE = "@rpath";
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                INFOPLIST_FILE = "Sources/Supporting Files/Info.plist";
+                INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+                IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+                PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOS";
+                PRODUCT_NAME = UtiliKit;
+                SKIP_INSTALL = YES;
+                SWIFT_VERSION = 4.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                VERSION = 1.2.1;
+                VERSIONING_SYSTEM = "apple-generic";
+                VERSION_INFO_PREFIX = "";
+            };
+            name = Release;
+        };
+        8677315220601BB400C54343 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CODE_SIGN_IDENTITY = "iPhone Developer";
+                CODE_SIGN_STYLE = Automatic;
+                DEBUG_INFORMATION_FORMAT = dwarf;
+                DEVELOPMENT_TEAM = "";
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
+                IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+                PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSTests";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                SWIFT_VERSION = 4.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                VERSION = 1.2.1;
+            };
+            name = Debug;
+        };
+        8677315320601BB400C54343 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CODE_SIGN_IDENTITY = "iPhone Developer";
+                CODE_SIGN_STYLE = Automatic;
+                DEVELOPMENT_TEAM = "";
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                INFOPLIST_FILE = "Tests/Supporting Files/Info.plist";
+                IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+                PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSTests";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 4.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                VERSION = 1.2.1;
+            };
+            name = Release;
+        };
+        8698CFE02061A19D0065AE20 /* Debug */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CODE_SIGN_IDENTITY = "iPhone Developer";
+                CODE_SIGN_STYLE = Automatic;
+                DEBUG_INFORMATION_FORMAT = dwarf;
+                DEVELOPMENT_TEAM = 2UAV38D2MU;
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                INFOPLIST_FILE = "Examples/UtiliKit-iOSExample/Info.plist";
+                IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+                PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSExample";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+                SWIFT_VERSION = 4.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                VERSION = 1.2.1;
+            };
+            name = Debug;
+        };
+        8698CFE12061A19D0065AE20 /* Release */ = {
+            isa = XCBuildConfiguration;
+            buildSettings = {
+                ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+                CLANG_ANALYZER_NONNULL = YES;
+                CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+                CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+                CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+                CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+                CODE_SIGN_IDENTITY = "iPhone Developer";
+                CODE_SIGN_STYLE = Automatic;
+                DEVELOPMENT_TEAM = 2UAV38D2MU;
+                GCC_C_LANGUAGE_STANDARD = gnu11;
+                INFOPLIST_FILE = "Examples/UtiliKit-iOSExample/Info.plist";
+                IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+                LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+                PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSExample";
+                PRODUCT_NAME = "$(TARGET_NAME)";
+                SWIFT_VERSION = 4.0;
+                TARGETED_DEVICE_FAMILY = "1,2";
+                VERSION = 1.2.1;
+            };
+            name = Release;
+        };
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "UtiliKit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				607FACED1AFB9204008FA782 /* Debug */,
-				607FACEE1AFB9204008FA782 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8677315420601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8677315020601BB400C54343 /* Debug */,
-				8677315120601BB400C54343 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8677315620601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8677315220601BB400C54343 /* Debug */,
-				8677315320601BB400C54343 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8698CFDF2061A19D0065AE20 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSExample" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8698CFE02061A19D0065AE20 /* Debug */,
-				8698CFE12061A19D0065AE20 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
+        607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "UtiliKit" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                607FACED1AFB9204008FA782 /* Debug */,
+                607FACEE1AFB9204008FA782 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        8677315420601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOS" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                8677315020601BB400C54343 /* Debug */,
+                8677315120601BB400C54343 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        8677315620601BB400C54343 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSTests" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                8677315220601BB400C54343 /* Debug */,
+                8677315320601BB400C54343 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
+        8698CFDF2061A19D0065AE20 /* Build configuration list for PBXNativeTarget "UtiliKit-iOSExample" */ = {
+            isa = XCConfigurationList;
+            buildConfigurations = (
+                8698CFE02061A19D0065AE20 /* Debug */,
+                8698CFE12061A19D0065AE20 /* Release */,
+            );
+            defaultConfigurationIsVisible = 0;
+            defaultConfigurationName = Release;
+        };
 /* End XCConfigurationList section */
-	};
-	rootObject = 607FACC81AFB9204008FA782 /* Project object */;
+    };
+    rootObject = 607FACC81AFB9204008FA782 /* Project object */;
 }

--- a/UtiliKit.xcodeproj/project.pbxproj
+++ b/UtiliKit.xcodeproj/project.pbxproj
@@ -666,7 +666,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
 				VERSION = 1.3.0;
 			};
 			name = Debug;
@@ -715,7 +714,6 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 				VERSION = 1.3.0;
 			};
@@ -747,6 +745,7 @@
 				PRODUCT_NAME = UtiliKit;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSION = 1.2.1;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -778,6 +777,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOS";
 				PRODUCT_NAME = UtiliKit;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSION = 1.2.1;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -804,6 +804,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSION = 1.2.1;
 			};
@@ -826,6 +827,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSION = 1.2.1;
 			};
@@ -851,6 +853,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSION = 1.2.1;
 			};
@@ -874,6 +877,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "bottlerocketstudios.UtiliKit-iOSExample";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSION = 1.2.1;
 			};


### PR DESCRIPTION
I saw Nuke was doing this to support compilation with both the Swift 4.1 compiler (Xcode 9) and Swift 4.2 compiler (Xcode 10). This will make it extremely easy for projects to migrate their dependencies to Xcode 10/Swift 4.2.

Eventually we can remove the conditional compilation when we want to support Swift 4.2+ (I think we're Swift 4.0+ or Swift 4.1+ currently). I also have a `feature/xcode10` branch in the works that logs the actual Swift 4.2 migration in the Xcode project file and updates the example target for Swift 4.2.