### PR TITLE
Container fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Allow calls to `transitionToController` before the view loads to have an effect at load time
+[Will McGinty](https://github.com/willmcginty)
+[#43](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/43)
 
 
 ## 1.3.3 (2018-10-25)

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -55,7 +55,7 @@ extension ContainerViewController {
     
     open func transitionToController(for child: ManagedChild, completion: ((Bool) -> Void)? = nil) {
         if !managedChildren.contains { $0.viewController === child.viewController } {
-            managedChildren.append(child)
+            managedChildren.insert(child, at: managedChildren.startIndex)
         }
         
         transition(to: child.viewController, completion: completion)


### PR DESCRIPTION
Allows calls to `transitionToController` with a previously unmanaged child before `viewDidLoad` to have an effect at load time. By placing the new child as the first object in `managedChildren` we ensure that it gets transitioned to at load time. This means that successive calls to `transitionToController` before `viewDidLoad` will result in the last call taking effect.