### PR TITLE
Another fix for pre-load transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Handle another case of transitioning pre-load.
 [Will McGinty](https://github.com/willmcginty)
-[#44](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/44)
+[#46](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/46)
 
 
 ## 1.3.4 (2018-12-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Handle another case of transitioning pre-load.
+[Will McGinty](https://github.com/willmcginty)
+[#44](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/44)
 
 
 ## 1.3.4 (2018-12-19)

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -58,6 +58,11 @@ extension ContainerViewController {
             managedChildren.insert(child, at: managedChildren.startIndex)
         }
         
+        if !isViewLoaded, managedChildren.first?.identifier != child.identifier {
+            managedChildren.removeAll { $0.identifier == child.identifier }
+            managedChildren.insert(child, at: managedChildren.startIndex)
+        }
+        
         transition(to: child.viewController, completion: completion)
     }
     


### PR DESCRIPTION
Deal with the case where the child is already managed, but not first in the list.