### PR TITLE
Fix an issue with constraint insets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 ##### Bug Fixes
 
-* None.
+* Fix an issue where right and bottom insets were being inverted in constraints.
+[Will McGinty](https://github.com/willmcginty)
+[#46](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/50)
 
 
 ## 1.3.5 (2019-01-02)

--- a/Sources/UtiliKit/General/UIView+Extensions.swift
+++ b/Sources/UtiliKit/General/UIView+Extensions.swift
@@ -59,9 +59,9 @@ public extension UIView {
         
         if isUsingSafeArea {
             superview.addConstraints([leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: insets.left),
-                                      trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: insets.right),
+                                      trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -insets.right),
                                       topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: insets.top),
-                                      bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: insets.bottom)])
+                                      bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -insets.bottom)])
         } else {
             constrainEdgesToSuperview(with: insets)
         }

--- a/Sources/UtiliKit/General/UIView+Extensions.swift
+++ b/Sources/UtiliKit/General/UIView+Extensions.swift
@@ -76,9 +76,9 @@ public extension UIView {
         guard let superview = superview else { return }
         
         superview.addConstraints([leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: insets.left),
-                                  trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: insets.right),
+                                  trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: -insets.right),
                                   topAnchor.constraint(equalTo: superview.topAnchor, constant: insets.top),
-                                  bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: insets.bottom)])
+                                  bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: -insets.bottom)])
     }
     
     /**

--- a/Tests/UtiliKitTests.swift
+++ b/Tests/UtiliKitTests.swift
@@ -48,4 +48,33 @@ class OpenSourceUtilitiesTests: XCTestCase {
         
         XCTAssertEqual(superview.constraints.count, 2)
     }
+    
+    func test_ConstrainSubviewWithInsets_InsetsAddedInCorrectDirection() {
+        let insets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        
+        superview.addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.constrainEdgesToSuperview(with: insets)
+        
+        superview.setNeedsLayout()
+        superview.layoutIfNeeded()
+        
+        XCTAssertEqual(superview.bounds.inset(by: insets), view.frame)
+    }
+    
+    @available(iOS 11, *)
+    func test_ConstrainSubviewInsideSafeAreaWithInsets_InsetsAddedInCorrectDirection() {
+        let insets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        
+        superview.addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        view.constrainEdgesToSuperview(with: insets, usingSafeArea: false)
+        
+        superview.setNeedsLayout()
+        superview.layoutIfNeeded()
+        
+        XCTAssertEqual(superview.bounds.inset(by: insets), view.frame)
+    }
 }


### PR DESCRIPTION
Fix an issue where insets were being applied in the inverse direction when constraining a view to its superview.