### PR TITLE
Fix an issue where the state of the container was incorrectly updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 [Will McGinty](https://github.com/willmcginty)
 [#76](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/76)
 
+* Fix an issue where the transition was mistakenly marked as a failure.
+[Will McGinty](https://github.com/willmcginty)
+[#77](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/77)
+
 ## 1.6.0 (2019-08-29)
 
 ##### Enhancements

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -116,9 +116,9 @@ private extension ContainerViewController {
     
     func configuredTransitionContext(from source: UIViewController, to destination: UIViewController, completion: ((Bool) -> Void)? = nil) -> ContainerTransitionContext {
         let context = ContainerTransitionContext(containerView: view, fromViewController: source, toViewController: destination)
-        context.completion = { [weak self] finished in
+        context.completion = { [unowned context, weak self] finished in
             guard let self = self else { return }
-            self.finishTransitioning(from: source, to: destination, success: finished, animated: true)
+            self.finishTransitioning(from: source, to: destination, success: !context.transitionWasCancelled, animated: true)
             self.delegate?.containerViewController(self, didFinishTransitioningFrom: source, to: destination)
             completion?(finished)
         }


### PR DESCRIPTION
This fixes an issue where the transition was considered cancelled when the animations do not finish. There are multiple cases when multiple animations are queued up that finished = false when the animation completes successfully. This updates the container's internal state based on whether or not the context was cancelled, instead of the animations finishing.