### PR TITLE
Fix an transition issue in iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 [Will McGinty](https://github.com/willmcginty)
 [#77](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/77)
 
+* Fix a transitionting issue where appearance callbacks were unbalanced in iOS 13.
+[Will McGinty](https://github.com/willmcginty)
+[#78](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/78)
+
 ## 1.6.0 (2019-08-29)
 
 ##### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 * Fix a transitionting issue where appearance callbacks were unbalanced in iOS 13.
 [Will McGinty](https://github.com/willmcginty)
-[#78](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/78)
+[#79](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/79)
 
 ## 1.6.0 (2019-08-29)
 

--- a/Sources/UtiliKit/Container/Transitioning/DefaultContainerTransitionAnimator.swift
+++ b/Sources/UtiliKit/Container/Transitioning/DefaultContainerTransitionAnimator.swift
@@ -12,23 +12,16 @@ class DefaultContainerTransitionAnimator: NSObject, UIViewControllerAnimatedTran
 
     // MARK: UIViewControllerAnimatedTransitioning
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
-        return 0.3
+        return 0.0
     }
     
-     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
-        guard let destinationController = transitionContext.viewController(forKey: .to),
-            let destination = destinationController.view, let source = transitionContext.view(forKey: .from) else {
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard let destinationController = transitionContext.viewController(forKey: .to), let destination = destinationController.view else {
             fatalError("The context is improperly configured - requires both a source and destination.")
         }
         
         transitionContext.containerView.addSubview(destination)
         destination.frame = transitionContext.finalFrame(for: destinationController)
-       
-       UIView.animate(withDuration: transitionDuration(using: transitionContext), animations: {
-           source.alpha = 0
-           destination.alpha = 1
-       }) { _ in
-           transitionContext.completeTransition(true)
-       }
+        transitionContext.completeTransition(true)
     }
 }


### PR DESCRIPTION
Using `transition(from:to:)` was causing unbalanced appearance calls to the transitioning controllers. Reverted to use a more standard (read: none) animation as the default - it is up to the user to provide an actual animation if they so wish.