### PR TITLE
Remove source or destination view from container after animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 [Will McGinty](https://github.com/willmcginty)
 [#79](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/79)
 
+* Fix an issue where ContainerViewController was not removing source or destination views from the view hierarchy after transitioning
+[Dimitar Milinski](https://github.com/dmilinski)
+[#81](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/81)
+
 ## 1.6.0 (2019-08-29)
 
 ##### Enhancements

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -149,12 +149,14 @@ private extension ContainerViewController {
         
         if success {
             source?.willMove(toParent: nil)
+            source?.view.removeFromSuperview()
             source?.removeFromParent()
            
             visibleController = destination
             
         } else {
             destination.willMove(toParent: nil)
+            destination.view.removeFromSuperview()
             destination.removeFromParent()
             
             visibleController = source


### PR DESCRIPTION
Talked to Will about this one and we felt it made sense to have the container do this, since it has the rest of the VC containment logic. 