### PR TITLE
Container tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ##### Enhancements
 
-* None
+* Make it possible to override functions in container, which aid in `ManagedChild` managemet.
+[Will McGinty](https://github.com/willmcginty)
+[#87](https://github.com/BottleRocketStudios/iOS-UtiliKit/pull/82)
 
 ##### Bug Fixes
 

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -51,23 +51,6 @@ open class ContainerViewController: UIViewController {
     }
     
     // MARK: Public Interface
-    open func transitionToControllerForChild(withIdentifier identifier: AnyHashable, completion: ((Bool) -> Void)? = nil) {
-        managedChildren.first { identifier == $0.identifier }.map { transitionToController(for: $0, completion: completion) }
-    }
-    
-    open func transitionToController(for child: ManagedChild, completion: ((Bool) -> Void)? = nil) {
-        if !managedChildren.contains { $0.viewController === child.viewController } {
-            managedChildren.insert(child, at: managedChildren.startIndex)
-        }
-        
-        if !isViewLoaded, managedChildren.first?.identifier != child.identifier {
-            managedChildren.removeAll { $0.identifier == child.identifier }
-            managedChildren.insert(child, at: managedChildren.startIndex)
-        }
-        
-        transition(to: child.viewController, completion: completion)
-    }
-    
     open func child(at index: Int) -> ManagedChild? {
         guard index >= managedChildren.startIndex && index < managedChildren.endIndex else { return nil }
         return managedChildren[index]
@@ -82,6 +65,15 @@ open class ContainerViewController: UIViewController {
             managedChildren.removeAll { $0.identifier == child.identifier }
             managedChildren.insert(child, at: managedChildren.startIndex)
         }
+    }
+    
+    open func transitionToControllerForChild(withIdentifier identifier: AnyHashable, completion: ((Bool) -> Void)? = nil) {
+        managedChildren.first { identifier == $0.identifier }.map { transitionToController(for: $0, completion: completion) }
+    }
+    
+    open func transitionToController(for child: ManagedChild, completion: ((Bool) -> Void)? = nil) {
+        addManagedChildIfNeeded(child)
+        transition(to: child.viewController, completion: completion)
     }
 }
 

--- a/Sources/UtiliKit/Container/ContainerViewController.swift
+++ b/Sources/UtiliKit/Container/ContainerViewController.swift
@@ -49,11 +49,8 @@ open class ContainerViewController: UIViewController {
         guard shouldAutomaticallyTransitionOnLoad, let initial = managedChildren.first else { return }
         transition(to: initial.viewController)
     }
-}
-
-//MARK: Public Interface
-extension ContainerViewController {
     
+    // MARK: Public Interface
     open func transitionToControllerForChild(withIdentifier identifier: AnyHashable, completion: ((Bool) -> Void)? = nil) {
         managedChildren.first { identifier == $0.identifier }.map { transitionToController(for: $0, completion: completion) }
     }
@@ -74,6 +71,17 @@ extension ContainerViewController {
     open func child(at index: Int) -> ManagedChild? {
         guard index >= managedChildren.startIndex && index < managedChildren.endIndex else { return nil }
         return managedChildren[index]
+    }
+    
+    open func addManagedChildIfNeeded(_ child: ManagedChild) {
+        if !managedChildren.contains { $0.viewController === child.viewController } {
+            managedChildren.insert(child, at: managedChildren.startIndex)
+        }
+        
+        if !isViewLoaded, managedChildren.first?.identifier != child.identifier {
+            managedChildren.removeAll { $0.identifier == child.identifier }
+            managedChildren.insert(child, at: managedChildren.startIndex)
+        }
     }
 }
 


### PR DESCRIPTION
Allows for child management to be overridden and customized (previously it was in an extension, so the compiler would not allow it be be overridden, despite the fact it was `open`).